### PR TITLE
Name nerve & static functions in function csv

### DIFF
--- a/data/progress.json
+++ b/data/progress.json
@@ -1,14 +1,14 @@
 {
     "matching": {
         "label": "matching",
-        "message": "4.59063%"
+        "message": "4.13518%"
     },
     "non_matching_minor": {
         "label": "non-matching (minor issues)",
-        "message": "0.03443%"
+        "message": "0.00000%"
     },
     "non_matching_major": {
         "label": "non-matching (major issues)",
-        "message": "0.01347%"
+        "message": "0.00000%"
     }
 }

--- a/data/shields.json
+++ b/data/shields.json
@@ -1,7 +1,7 @@
 {
     "schemaVersion": 1,
     "label": "decompiled",
-    "message": "4.591%",
+    "message": "4.135%",
     "color": "blue",
     "cacheSeconds": 3600,
     "style": "flat"


### PR DESCRIPTION
I've added all unnamed functions back into the csv now that nerve functions have been automatically named. `tools/check` is able to find these newly named execute functions and match them at the same time as the exe function. Static init functions for Game and al have also been named, but I wouldn't expect anything in the decomp currently that would create one of those functions.

The nerve macro still needs to be fixed for nerves without a struct, causing a mismatch on data symbols, but that should be done in a separate PR.

10 matched functions were lost to the void in one of the recent comments. I'm guessing that somebody matched the functions and then removed them, but `tools/check` does not pick this up.

In total, 7963 functions were added back into the csv, causing a progress decrease of 0.508%. Over 6800 of these functions are nerves and can now be matched.

Our 31 non-matching functions have been removed as a result of wiping the csv progress, `tools/check` does not mark these automatically so they have also been lost until they're manually checked again. I'm not sure how that should work.